### PR TITLE
make appimage work on any linux system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:20.04
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y software-properties-common
 RUN add-apt-repository -y ppa:alex-p/tesseract-ocr
-RUN DEBIAN_FRONTEND=noninteractive apt install -y debhelper libleptonica-dev automake libtool libarchive-dev libpango1.0-dev libcairo2-dev libicu-dev libpng-dev libjpeg-dev libtiff-dev zlib1g-dev git asciidoc xsltproc docbook-xsl docbook-xml wget libfuse2 fuse
+RUN DEBIAN_FRONTEND=noninteractive apt install -y desktop-file-utils debhelper libleptonica-dev automake libtool libarchive-dev libpango1.0-dev libcairo2-dev libicu-dev libpng-dev libjpeg-dev libtiff-dev zlib1g-dev git asciidoc xsltproc docbook-xsl docbook-xml wget libfuse2 fuse
 
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot wget
-RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+RUN wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
 RUN chmod +x /usr/local/bin/appimagetool
 
 #RUN pip3 install appimage-builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y software-properties-common
 RUN add-apt-repository -y ppa:alex-p/tesseract-ocr
-RUN DEBIAN_FRONTEND=noninteractive apt install -y desktop-file-utils debhelper libleptonica-dev automake libtool libarchive-dev libpango1.0-dev libcairo2-dev libicu-dev libpng-dev libjpeg-dev libtiff-dev zlib1g-dev git asciidoc xsltproc docbook-xsl docbook-xml wget libfuse2 fuse
+RUN DEBIAN_FRONTEND=noninteractive apt install -y patchelf desktop-file-utils debhelper libleptonica-dev automake libtool libarchive-dev libpango1.0-dev libcairo2-dev libicu-dev libpng-dev libjpeg-dev libtiff-dev zlib1g-dev git asciidoc xsltproc docbook-xsl docbook-xml wget libfuse2 fuse
 
 RUN DEBIAN_FRONTEND=noninteractive apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot wget
 RUN wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool

--- a/build.sh
+++ b/build.sh
@@ -191,13 +191,18 @@ EOF
 
 chmod +x AppDir/AppRun
 
-patchelf --set-rpath '$ORIGIN/../lib' AppDir/usr/bin/tesseract
+patchelf --set-rpath '$ORIGIN/../lib' AppDir/usr/bin/tesseract || exit 1
 
-ldd AppDir/usr/bin/tesseract | awk -F"[> ]" '{print $4}' | xargs -I {} cp -f {} AppDir/usr/lib
-mv AppDir/usr/lib/ld-linux-x86-64.so.2 AppDir || exit 1
-find /lib /usr/lib -type f -name 'libtiff.so.5' -exec cp {} AppDir/usr/lib
+ldd AppDir/usr/bin/tesseract | awk -F"[> ]" '{print $4}' | xargs -I {} cp -vf {} AppDir/usr/lib
+mv AppDir/usr/lib/ld-linux-x86-64.so.2 AppDir 2>/dev/null || true
 
-patchelf --set-rpath '$ORIGIN' ./usr/lib/*
+if [ ! -f AppDir/ld-linux-x86-64.so.2 ]; then
+    cp -v /lib64/ld-linux-x86-64.so.2 AppDir || exit 1
+fi
+
+cp -v /usr/lib/x86_64-linux-gnu/libtiff.so.5 AppDir/usr/lib || exit 1
+
+patchelf --set-rpath '$ORIGIN' AppDir/usr/lib/lib* || exit 1
 
 appimagetool AppDir
 

--- a/build.sh
+++ b/build.sh
@@ -25,28 +25,7 @@ LANG_TESSDATA=("afr" "amh" "ara" "asm" "aze_cyrl" "aze" "bel" "ben" "bod" \
                "tat" "tel" "tgk" "tha" "tir" "ton" "tur" "uig" "ukr" "urd" \
                "uzb_cyrl" "uzb" "vie" "yid" "yor")
 INSTALL_TESSDATA=("eng" "osd")
-LIB="/usr/lib/x86_64-linux-gnu/libarchive.so.13
-     /lib/x86_64-linux-gnu/libattr.so.1\
-     /lib/x86_64-linux-gnu/libbz2.so.1.0\
-     /usr/lib/x86_64-linux-gnu/libgif.so.7\
-     /usr/lib/x86_64-linux-gnu/libgomp.so.1\
-     /usr/lib/x86_64-linux-gnu/libicudata.so.66 \
-     /usr/lib/x86_64-linux-gnu/libicuuc.so.66\
-     /usr/lib/x86_64-linux-gnu/libjbig.so.0\
-     /usr/lib/x86_64-linux-gnu/libjpeg.so.8\
-     /usr/lib/x86_64-linux-gnu/liblept.so.5\
-     /lib/x86_64-linux-gnu/liblzma.so.5 \
-     /lib/x86_64-linux-gnu/liblzo2.so.2\
-     /usr/lib/x86_64-linux-gnu/libnettle.so.7\
-     /usr/lib/x86_64-linux-gnu/libopenjp2.so.7\
-     /usr/lib/x86_64-linux-gnu/libpng16.so.16 \
-     /usr/lib/x86_64-linux-gnu/libtiff.so.5\
-     /usr/lib/x86_64-linux-gnu/libwebp.so.6\
-     /usr/lib/x86_64-linux-gnu/libxml2.so.2\
-     /lib/x86_64-linux-gnu/libz.so.1
-     /lib/x86_64-linux-gnu/libacl.so.1\
-     /usr/lib/x86_64-linux-gnu/liblz4.so.1\
-     /usr/lib/x86_64-linux-gnu/libwebpmux.so.3"
+
 
 get_tessdata(){
     if test ! -f "${1}.traineddata"
@@ -67,7 +46,7 @@ get_tessdata(){
 while getopts "l:n" Option
 do
     case $Option in
-        l) 
+        l)
         for _lang in $OPTARG
         do
             if printf '%s\n' "${LANG_TESSDATA[@]}" | grep -q "^${_lang}$"
@@ -195,35 +174,30 @@ cat >> "AppDir/AppRun" << EOF
 #!/bin/bash
 HERE="\$(dirname "\$(readlink -f "\${0}")")"
 
-export LD_LIBRARY_PATH=\${HERE}/usr/lib:\$LD_LIBRARY_PATH
-
-if [ -z "\$TESSDATA_PREFIX" ]
-then
+if [ -z "\$TESSDATA_PREFIX" ]; then
     export TESSDATA_PREFIX=\${HERE}${_TESSDATA_PREFIX}/tessdata
 fi
 
-if [ ! -z \$APPIMAGE ] ; then
-  BINARY_NAME=\$(basename "\$ARGV0")
+if [ ! -z \$APPIMAGE ]; then
+  BINARY_NAME=\$(basename "\${ARGV0#./}")
 else
   BINARY_NAME=\$(basename "\$0")
 fi
 
-exec "\${HERE}/usr/bin/tesseract" "\$@"
+unset ARGV0
+
+exec "\${HERE}/ld-linux-x86-64.so.2" "\${HERE}/usr/bin/tesseract" "\$@"
 EOF
 
 chmod +x AppDir/AppRun
 
-#ldd AppDir/usr/bin/tesseract
+patchelf --set-rpath '$ORIGIN/../lib' ./usr/bin/tesseract
 
-for i in $LIB
-do
-  cp "${i}" "$(pwd)/AppDir/usr/lib" || exit 1
-done
+ldd ./usr/bin/tesseract | awk -F"[> ]" '{print $4}' | xargs -I {} cp -f {} ./usr/lib
+mv ./usr/lib/ld-linux-x86-64.so.2 ./ || exit 1
+find /lib /usr/lib -type f -name 'libtiff.so.5' -exec cp {} ./usr/lib
 
-LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(pwd)/AppDir/usr/lib"
-export LD_LIBRARY_PATH
-
-#ldd AppDir/usr/bin/tesseract
+patchelf --set-rpath '$ORIGIN' ./usr/lib/*
 
 appimagetool AppDir
 

--- a/build.sh
+++ b/build.sh
@@ -191,11 +191,11 @@ EOF
 
 chmod +x AppDir/AppRun
 
-patchelf --set-rpath '$ORIGIN/../lib' ./usr/bin/tesseract
+patchelf --set-rpath '$ORIGIN/../lib' AppDir/usr/bin/tesseract
 
-ldd ./usr/bin/tesseract | awk -F"[> ]" '{print $4}' | xargs -I {} cp -f {} ./usr/lib
-mv ./usr/lib/ld-linux-x86-64.so.2 ./ || exit 1
-find /lib /usr/lib -type f -name 'libtiff.so.5' -exec cp {} ./usr/lib
+ldd AppDir/usr/bin/tesseract | awk -F"[> ]" '{print $4}' | xargs -I {} cp -f {} AppDir/usr/lib
+mv AppDir/usr/lib/ld-linux-x86-64.so.2 AppDir || exit 1
+find /lib /usr/lib -type f -name 'libtiff.so.5' -exec cp {} AppDir/usr/lib
 
 patchelf --set-rpath '$ORIGIN' ./usr/lib/*
 


### PR DESCRIPTION
Turns out go-appimage isn't needed and this all can be done manually. 

Closes #3 

Tested on Bbuntu 20.04, Artix and Alpine, here is alpine: 

![image](https://github.com/user-attachments/assets/2cd9ca27-dcfb-40ed-915f-d40f4844af6f)

EDIT: The appimage ends up being 56.1 MiB, smaller than the current one due to the zstd compression.