### PR TITLE
make `AppRun` more portable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -147,7 +147,7 @@ cp "${DIR}/tesseract.png" "AppDir"
 
 
 cat >> "AppDir/AppRun" << EOF
-#!/bin/bash
+#!/bin/sh
 HERE="\$(dirname "\$(readlink -f "\${0}")")"
 
 if [ -z "\$TESSDATA_PREFIX" ]; then


### PR DESCRIPTION
this way it works on alpine which doesnt have `bash` by default. 

Btw is there a need for this? 

```shell
if [ ! -z \$APPIMAGE ]; then
  BINARY_NAME=\$(basename "\${ARGV0#./}")
else
  BINARY_NAME=\$(basename "\$0")
fi
```

Unless `tesseract` uses that var internally, that can be removed. 